### PR TITLE
Bump CircleCI setup_remote_docker and add Authentication using org-global context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ global_dockerhub_auth: &global_dockerhub_auth
 version: 2
 defaults: &defaults
   docker:
-    - image: deliveroo/circleci:0.2.2
+    - image: deliveroo/circleci:0.4.2
       <<: *global_dockerhub_auth
 remote_docker: &remote_docker
   docker_layer_caching: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,138 +1,121 @@
+# GLOBAL-ANCHORS - DockerHub Authentication changes applied - PROD-1431 / PROD-1435
+global_context: &global_context
+  context:
+    - org-global
+global_remote_docker: &global_remote_docker
+  version: 19.03.13
+global_dockerhub_auth: &global_dockerhub_auth
+  auth:
+    username: $GLOBAL_DOCKERHUB_USERNAME
+    password: $GLOBAL_DOCKERHUB_PASSWORD
 version: 2
-
 defaults: &defaults
   docker:
-  - image: deliveroo/circleci:0.2.2
-
+    - image: deliveroo/circleci:0.2.2
+      <<: *global_dockerhub_auth
 remote_docker: &remote_docker
   docker_layer_caching: true
   reusable: true
-  version: 17.09.0-ce
-
+  <<: *global_remote_docker
 import_image: &import_image
   name: Import Docker image
   command: |
     set -ex
     docker load --input "workspace/${CIRCLE_PROJECT_REPONAME}-${CIRCLE_SHA1}.tar"
-
 jobs:
   build:
     <<: *defaults
-
     steps:
-    - setup_remote_docker:
-        <<: *remote_docker
-
-    - checkout
-
-    - run:
-        name: Build CI Image
-        command: |
-          docker build -f Dockerfile -t $(./image) .
-
-    - run:
-        name: Save CI Image
-        command: |
-          mkdir -p workspace
-          docker save $(./image) \
-              --output "workspace/${CIRCLE_PROJECT_REPONAME}-${CIRCLE_SHA1}.tar"
-
-    - persist_to_workspace:
-        root: workspace
-        paths:
-        - "*.tar"
-
+      - setup_remote_docker:
+          <<: *remote_docker
+      - checkout
+      - run:
+          name: Build CI Image
+          command: |
+            docker build -f Dockerfile -t $(./image) .
+      - run:
+          name: Save CI Image
+          command: |
+            mkdir -p workspace
+            docker save $(./image) \
+                --output "workspace/${CIRCLE_PROJECT_REPONAME}-${CIRCLE_SHA1}.tar"
+      - persist_to_workspace:
+          root: workspace
+          paths:
+            - "*.tar"
   push_master:
     <<: *defaults
     steps:
-    - add_ssh_keys:
-        fingerprints:
-          # Stored in 1Password 'Engineering' vault as 'nginx-sidecar GitHub SSH'
-          - f8:d2:c8:03:c4:41:99:4f:07:e6:c0:0b:94:70:04:80
-
-    - setup_remote_docker:
-        <<: *remote_docker
-
-    - checkout
-
-    - attach_workspace:
-        at: workspace
-
-    - run:
-        <<: *import_image
-
-    - run:
-        name: Tag the git commit
-        command: |
-          # This fails if the tag already exists
-          # preventing a push to the docker hub.
-          git tag "$(cat VERSION)"
-          git push --tags
-
-    - run:
-        name: Log in to Docker repository
-        command: docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
-
-    - run:
-        name: Push the image
-        command: docker push $(./image)
-
+      - add_ssh_keys:
+          fingerprints:
+            # Stored in 1Password 'Engineering' vault as 'nginx-sidecar GitHub SSH'
+            - f8:d2:c8:03:c4:41:99:4f:07:e6:c0:0b:94:70:04:80
+      - setup_remote_docker:
+          <<: *remote_docker
+      - checkout
+      - attach_workspace:
+          at: workspace
+      - run:
+          <<: *import_image
+      - run:
+          name: Tag the git commit
+          command: |
+            # This fails if the tag already exists
+            # preventing a push to the docker hub.
+            git tag "$(cat VERSION)"
+            git push --tags
+      - run:
+          name: Log in to Docker repository
+          command: docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
+      - run:
+          name: Push the image
+          command: docker push $(./image)
   push_staging:
     <<: *defaults
     steps:
-    - add_ssh_keys:
-        fingerprints:
-          # Stored in 1Password 'Engineering' vault as 'nginx-sidecar GitHub SSH'
-          - f8:d2:c8:03:c4:41:99:4f:07:e6:c0:0b:94:70:04:80
-
-    - setup_remote_docker:
-        <<: *remote_docker
-
-    - checkout
-
-    - attach_workspace:
-        at: workspace
-
-    - run:
-        <<: *import_image
-
-    - run:
-        name: Log in to Docker repository
-        command: docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
-
-    - run:
-        name: Tag the Docker image
-        command: docker tag $(./image) "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}:staging"
-
-    - run:
-        name: Push the image
-        command: docker push "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}:staging"
-
+      - add_ssh_keys:
+          fingerprints:
+            # Stored in 1Password 'Engineering' vault as 'nginx-sidecar GitHub SSH'
+            - f8:d2:c8:03:c4:41:99:4f:07:e6:c0:0b:94:70:04:80
+      - setup_remote_docker:
+          <<: *remote_docker
+      - checkout
+      - attach_workspace:
+          at: workspace
+      - run:
+          <<: *import_image
+      - run:
+          name: Log in to Docker repository
+          command: docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
+      - run:
+          name: Tag the Docker image
+          command: docker tag $(./image) "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}:staging"
+      - run:
+          name: Push the image
+          command: docker push "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}:staging"
 master_only: &master_only
   filters:
     branches:
       only:
-      - master
-
+        - master
 staging_only: &staging_only
   filters:
     branches:
       only:
-      - staging
-
+        - staging
 workflows:
   version: 2
-
   build_and_push:
     jobs:
-      - build
-
+      - build:
+          <<: *global_context
       - push_master:
           <<: *master_only
           requires:
-          - build
-
+            - build
+          <<: *global_context
       - push_staging:
           <<: *staging_only
           requires:
-          - build
+            - build
+          <<: *global_context


### PR DESCRIPTION
PROD-1435: Changes relating to enforcing Docker Hub authentication on CircleCI

- Enforces all actions using Docker Hub to use authentication (not anonymous)
  using CircleCI Global Context - org-global

- Changes Docker setup_remote_docker version to be updated to 19.03.13 due to
  deprecation from CircleCI of older versions

