### PR TITLE
Add retry step for Container Health status check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,7 @@ jobs:
       NGINX_PORT: 8001
       APP_PORT: 8000
       APP_HOST: echo-server-test
+      NGINX_TEST_SERVICE: nginx-test
     steps:
       - *global_remote_docker
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,12 +68,23 @@ jobs:
             set -x
             docker-compose -f docker-compose.ci.yml -p nginx-sidecar run wait-test wfi nginx-test:8001 --timeout=60
       - run:
-          name: Check Healthy Sidecar status
-          command: |
-            [ "$(docker inspect -f {{.State.Health.Status}} nginx-test)" = "healthy" ] \
-            && echo "Healty Container" \
-            || { echo "Container state:$(docker inspect -f {{.State.Health.Status}} nginx-test)"; exit 1; }
-
+            name: Check Nginx Sidecar status is healthy
+            command: |
+              container_success="healthy"
+              n=0
+              until [ "$n" -ge 3 ]
+              do
+                  result="$(docker inspect -f {{.State.Health.Status}} ${NGINX_TEST_SERVICE})"
+                  if [ "$result" = "$container_success" ]; then
+                          echo "Healthy ${NGINX_TEST_SERVICE} container found"
+                          exit 0
+                  else
+                          echo "Container health: $(docker inspect -f {{.State.Health.Status}} ${NGINX_TEST_SERVICE})"
+                          n=$((n+1))
+                          sleep 1;
+                  fi
+              done
+              exit 1
   push_master:
     parameters:
       publish_to_docker_hub:


### PR DESCRIPTION
Added short retry loop that allows a container to go from `starting` to `healthy` without failing the CI/CD test.