### PR TITLE
infra: use US aws provider for ecr public iam policy

### DIFF
--- a/infrastructure/modules/basic/iam.tf
+++ b/infrastructure/modules/basic/iam.tf
@@ -72,6 +72,7 @@ data "aws_iam_policy_document" "ecr_policy" {
   }
 }
 resource "aws_ecrpublic_repository_policy" "ecr_policy" {
+  provider        = aws.us_east_1
   repository_name = aws_ecrpublic_repository.nginx-sidecar.repository_name
   policy          = data.aws_iam_policy_document.ecr_policy.json
 }


### PR DESCRIPTION
Public ECR repos can only be created in the us-east-1 region and we've done that, however the resource policy also needs to use the US provider otherwise the plan fails as it cannot find a public repo in the EU region.

Ticket number NEC-2356
https://deliveroo.atlassian.net/browse/NEC-2356
