### PR TITLE
infra: switch to using private ECR repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,12 +79,6 @@ jobs:
                 command: |
                   echo "Not publishing to Docker Hub or incrementing the GitHub tags.\n\nSet the publish_to_docker_hub value to \"true\" if you want to publish."
             - run: circleci-agent step halt
-      - aws-cli/setup:
-          role-arn: ${OIDC_ROLE_ARN}
-          aws-region: ${ECR_AWS_REGION} # Public ECR Repo
-          role-session-name: nginx-sidecar-publish
-          profile-name: OIDC-PROFILE
-
       - add_ssh_keys:
           fingerprints:
             - a7:2f:cb:c2:b3:6a:17:c4:8f:3a:8d:77:57:d3:41:bb
@@ -119,7 +113,7 @@ jobs:
             - a7:2f:cb:c2:b3:6a:17:c4:8f:3a:8d:77:57:d3:41:bb
       - aws-cli/setup:
           role-arn: ${OIDC_ROLE_ARN}
-          aws-region: us-east-1 # Public ECR Repo
+          aws-region: ECR_AWS_REGION
           role-session-name: nginx-sidecar-publish
           profile-name: OIDC-PROFILE
       - *global_remote_docker
@@ -131,19 +125,17 @@ jobs:
       - run:
           name: Tag the Docker image
           command: docker tag $(./image) "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}:staging"
-      - run:
-          name: Push the image to Dockerhub
-          command: docker push "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}:staging"
+      # - run:
+      #     name: Push the image to Dockerhub
+      #     command: docker push "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}:staging"
       - run:
           name: Push to Public ECR
           command: |
             # Get the ECR Password and log in to Docker
-            aws ecr-public get-login-password --profile OIDC-PROFILE | \
-            docker login --username AWS --password-stdin public.ecr.aws
-            # Tag the image with the ECR Repo
-            docker tag "$(./image)" "${AWS_ECR_REPO_URL}"
+            aws ecr get-login-password --profile OIDC-PROFILE | \
+            docker login --username AWS --password-stdin ${AWS_ECR_REPO_URL}
             # Push it up
-            docker push "${AWS_ECR_REPO_URL}"
+            docker push "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}:staging"
 
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,6 @@ jobs:
             - a7:2f:cb:c2:b3:6a:17:c4:8f:3a:8d:77:57:d3:41:bb
       - aws-cli/setup:
           role-arn: ${OIDC_ROLE_ARN}
-          aws-region: ECR_AWS_REGION
           role-session-name: nginx-sidecar-publish
           profile-name: OIDC-PROFILE
       - *global_remote_docker

--- a/infrastructure/environments/platform/data.tf
+++ b/infrastructure/environments/platform/data.tf
@@ -1,2 +1,2 @@
 data "roo_tags" "global_platform" {}
-data "roo_aws_account" "global" {}
+data "roo_shard_info" "current" {}

--- a/infrastructure/environments/platform/providers.tf
+++ b/infrastructure/environments/platform/providers.tf
@@ -7,7 +7,7 @@ provider "aws" {
   }
 
   assume_role {
-    role_arn     = data.roo_aws_account.global.terraform_deploy_role_arn
+    role_arn     = data.roo_shard_info.current.terraform_deploy_role_arn
     session_name = "geopoiesis-global_platform"
   }
 }
@@ -20,7 +20,7 @@ provider "aws" {
     tags = data.roo_tags.global_platform.aws_tags
   }
   assume_role {
-    role_arn     = data.roo_aws_account.global.terraform_deploy_role_arn
+    role_arn     = data.roo_shard_info.current.terraform_deploy_role_arn
     session_name = "geopoiesis-global_eu_east_1_platform"
   }
 }

--- a/infrastructure/modules/basic/circleci.tf
+++ b/infrastructure/modules/basic/circleci.tf
@@ -14,9 +14,9 @@ resource "circleci_envvar" "oidc_role" {
   variable_value = aws_iam_role.circleci_oidc.arn
 }
 
-resource "circleci_envvar" "aws_ecr_repo_region" {
+resource "circleci_envvar" "aws_region" {
   vcs_provider   = "github"
   project_name   = local.circleci_project_name
-  variable_name  = "DEFAULT_AWS_REGION"
+  variable_name  = "AWS_DEFAULT_REPO"
   variable_value = "eu-west-1"
 }

--- a/infrastructure/modules/basic/circleci.tf
+++ b/infrastructure/modules/basic/circleci.tf
@@ -1,8 +1,10 @@
 resource "circleci_envvar" "aws_ecr_repo" {
-  vcs_provider   = "github"
-  project_name   = local.circleci_project_name
-  variable_name  = "AWS_ECR_REPO_URL"
-  variable_value = aws_ecrpublic_repository.nginx-sidecar.repository_uri
+  vcs_provider  = "github"
+  project_name  = local.circleci_project_name
+  variable_name = "AWS_ECR_REPO_URL"
+  # input: aws_account_id.dkr.ecr.region.amazonaws.com/repositoryName
+  # output: aws_account_id.dkr.ecr.region.amazonaws.com
+  variable_value = split("/", aws_ecr_repository.nginx-sidecar.repository_uri)[0]
 }
 
 resource "circleci_envvar" "oidc_role" {
@@ -15,6 +17,6 @@ resource "circleci_envvar" "oidc_role" {
 resource "circleci_envvar" "aws_ecr_repo_region" {
   vcs_provider   = "github"
   project_name   = local.circleci_project_name
-  variable_name  = "ECR_AWS_REGION"
-  variable_value = "us-east-1"
+  variable_name  = "DEFAULT_AWS_REGION"
+  variable_value = "eu-west-1"
 }

--- a/infrastructure/modules/basic/data.tf
+++ b/infrastructure/modules/basic/data.tf
@@ -1,2 +1,2 @@
-data "aws_default_tags" "current" {}
 data "aws_caller_identity" "current" {}
+data "roo_environment" "current" {}

--- a/infrastructure/modules/basic/iam.tf
+++ b/infrastructure/modules/basic/iam.tf
@@ -27,6 +27,7 @@ data "aws_iam_policy_document" "circleci_oidc" {
       "ecr:BatchGetImage",
       "ecr:CompleteLayerUpload",
       "ecr:DescribeRepositories",
+      "ecr:GetAuthorizationToken",
       "ecr:GetDownloadUrlForLayer",
       "ecr:InitiateLayerUpload",
       "ecr:ListImages",
@@ -64,6 +65,7 @@ data "aws_iam_policy_document" "ecr_policy" {
     }
 
     actions = [
+      "ecr:GetAuthorizationToken",
       "ecr:GetDownloadUrlForLayer",
       "ecr:BatchGetImage",
       "ecr:BatchCheckLayerAvailability",

--- a/infrastructure/modules/basic/iam.tf
+++ b/infrastructure/modules/basic/iam.tf
@@ -23,18 +23,18 @@ resource "aws_iam_role" "circleci_oidc" {
 data "aws_iam_policy_document" "circleci_oidc" {
   statement {
     actions = [
-      "ecr-public:BatchCheckLayerAvailability",
-      "ecr-public:BatchGetImage",
-      "ecr-public:CompleteLayerUpload",
-      "ecr-public:DescribeRepositories",
-      "ecr-public:GetDownloadUrlForLayer",
-      "ecr-public:InitiateLayerUpload",
-      "ecr-public:ListImages",
-      "ecr-public:PutImage",
-      "ecr-public:UploadLayerPart",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:BatchGetImage",
+      "ecr:CompleteLayerUpload",
+      "ecr:DescribeRepositories",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:InitiateLayerUpload",
+      "ecr:ListImages",
+      "ecr:PutImage",
+      "ecr:UploadLayerPart",
     ]
 
-    resources = [aws_ecrpublic_repository.nginx-sidecar.arn]
+    resources = [aws_ecr_repository.nginx-sidecar.arn]
   }
 }
 
@@ -50,29 +50,33 @@ resource "aws_iam_role_policy_attachment" "circleci_oidc" {
 
 data "aws_iam_policy_document" "ecr_policy" {
   statement {
-    sid    = "NginxSidecarPublicECRPolicy"
+    sid    = "NginxSidecarECRPolicy"
     effect = "Allow"
 
     principals {
       type        = "AWS"
-      identifiers = [aws_iam_role.circleci_oidc.arn]
+      identifiers = ["*"]
+    }
+    condition {
+      test     = "ForAnyValue:StringLike"
+      values   = [data.roo_environment.current.apps_aws_organization_path]
+      variable = "aws:PrincipalOrgPaths"
     }
 
     actions = [
-      "ecr-public:GetDownloadUrlForLayer",
-      "ecr-public:BatchGetImage",
-      "ecr-public:BatchCheckLayerAvailability",
-      "ecr-public:PutImage",
-      "ecr-public:InitiateLayerUpload",
-      "ecr-public:UploadLayerPart",
-      "ecr-public:CompleteLayerUpload",
-      "ecr-public:DescribeRepositories",
-      "ecr-public:ListImages",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:PutImage",
+      "ecr:InitiateLayerUpload",
+      "ecr:UploadLayerPart",
+      "ecr:CompleteLayerUpload",
+      "ecr:DescribeRepositories",
+      "ecr:ListImages",
     ]
   }
 }
-resource "aws_ecrpublic_repository_policy" "ecr_policy" {
-  provider        = aws.us_east_1
-  repository_name = aws_ecrpublic_repository.nginx-sidecar.repository_name
-  policy          = data.aws_iam_policy_document.ecr_policy.json
+resource "aws_ecr_repository_policy" "ecr_policy" {
+  repository = aws_ecr_repository.nginx-sidecar.repository_name
+  policy     = data.aws_iam_policy_document.ecr_policy.json
 }

--- a/infrastructure/modules/basic/locals.tf
+++ b/infrastructure/modules/basic/locals.tf
@@ -1,9 +1,4 @@
 locals {
-  iam_tags_for_shared_policies = {
-    ECRRepoName = local.ecr_repo_name
-  }
-  default_tags = merge(data.aws_default_tags.current.tags, local.iam_tags_for_shared_policies)
-
   circleci_oidc_url           = "oidc.circleci.com/org/"
   circleci_org_id             = "c53c93bf-aea8-45c3-9aae-984a3f5229a3"
   circleci_oidc_subject_claim = "sub"

--- a/infrastructure/modules/basic/main.tf
+++ b/infrastructure/modules/basic/main.tf
@@ -1,14 +1,6 @@
-// A public ECR repo for the image so we can reference a public URL
-// instead of needing to use an account ID
-resource "aws_ecrpublic_repository" "nginx-sidecar" {
-  provider = aws.us_east_1
-
-  repository_name = local.ecr_repo_name
-
-  catalog_data {
-    about_text        = local.ecr_desc
-    description       = local.ecr_desc
-    operating_systems = ["Linux"]
+resource "aws_ecr_repository" "nginx-sidecar" {
+  name = local.ecr_repo_name
+  image_scanning_configuration {
+    scan_on_push = true
   }
 }
-

--- a/infrastructure/modules/basic/variables.tf
+++ b/infrastructure/modules/basic/variables.tf
@@ -1,4 +1,11 @@
 variable "env_name" {
   type        = string
   description = "The environment, e.g. 'production'"
+  default     = "platform"
+}
+
+variable "region" {
+  type        = string
+  description = "AWS Region"
+  default     = "eu-west-1"
 }

--- a/infrastructure/modules/basic/versions.tf
+++ b/infrastructure/modules/basic/versions.tf
@@ -1,8 +1,9 @@
 terraform {
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = "~> 5.70"
+      source                = "hashicorp/aws"
+      version               = "~> 5.70"
+      configuration_aliases = [aws.us_east_1]
     }
     circleci = {
       source  = "terraform-registry.deliveroo.net/deliveroo/circleci"


### PR DESCRIPTION
The sidecar isn't used anywhere outside of our infra that would justify having the images be published publically.

It'll make our job easier if we have this in a private repo.

Ticket number NEC-2356
https://deliveroo.atlassian.net/browse/NEC-2356
