### PR TITLE
infra: allow getting auth token on all resources

### DIFF
--- a/infrastructure/modules/basic/iam.tf
+++ b/infrastructure/modules/basic/iam.tf
@@ -27,7 +27,6 @@ data "aws_iam_policy_document" "circleci_oidc" {
       "ecr:BatchGetImage",
       "ecr:CompleteLayerUpload",
       "ecr:DescribeRepositories",
-      "ecr:GetAuthorizationToken",
       "ecr:GetDownloadUrlForLayer",
       "ecr:InitiateLayerUpload",
       "ecr:ListImages",
@@ -36,6 +35,11 @@ data "aws_iam_policy_document" "circleci_oidc" {
     ]
 
     resources = [aws_ecr_repository.nginx-sidecar.arn]
+  }
+
+  statement {
+    actions   = ["ecr:GetAuthorizationToken"]
+    resources = ["*"]
   }
 }
 


### PR DESCRIPTION
I believe this action requires a more permissive resource to work, like we do [here](https://github.com/deliveroo/core-infrastructure/blob/main/modules/shared_iam_policies/ecr_repo_access.tf#L31-L41)

Ticket number NEC-2356
https://deliveroo.atlassian.net/browse/NEC-2356
