### PR TITLE
README: rewrite document to reflect new ways of working with hopper

### DIFF
--- a/scripts/download_image
+++ b/scripts/download_image
@@ -1,0 +1,11 @@
+#!/bin/env bash
+# Requires readonly AWS CLI permissions
+
+image_base=930404128139.dkr.ecr.eu-west-1.amazonaws.com/nginx-sidecar
+version=staging
+
+[ -n "$1" ] && version=$1
+
+aws ecr get-login-password | docker login --username AWS --password-stdin https://${image_base}
+docker pull ${image_base}:${version}
+


### PR DESCRIPTION
Hopper now has the functionality to allow us to define `nginx` as a proper sidecar. We can now abstract away the complexities of setting up this sidecar so I've updated the README to reflect that.

Ticket number NEC-2356
https://deliveroo.atlassian.net/browse/NEC-2356
