### PR TITLE
README: update documentation to reflect new hopper schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,54 +31,61 @@ The following is an example of how to set up `nginx` with default settings, pass
 # ...
 
 services:
-  web:
+  - type: Hopper::Services::ECS::Service
+    name: web
     sidecars:
       nginx:
-        # Needs to match your service name, in this case it's 'web', because nginx
-        # will be the main entry container for your service.
-        container_name: web
-        # The port Nginx will listen on, i.e. the port the ALB should forward requests to.
-        # This must match the port you've defined for your service with `roo-service`
+        # By default the Nginx container will be named after the service, in this case "web"
+        # and by defining an Nginx port we will assume your app container uses the same port.
+        # Note: both the container name and the app port are configurable if needed
         nginx_port: 8008
-        # The port your application container is listening on. Nginx will forward requests to this port.
-        app_port: 8008
-    containerDefinitions:
-      # Your application container, defined as normal, but named 'app'
-      # Note: you can change the container name you use here, see the
-      # optional customisation sections of this README for more information
-      app:
-        cpu: 1024
-        memory: 1024
-        essential: true
-        command: "exec puma -p 3001 -C config/puma.rb"
+    taskDefinitions:
+        containerDefinitions:
+          # Your application container, defined as normal, but named 'app'
+          # Note: you can change the container name you use here, see the
+          # optional customisation sections of this README for more information
+          - name: app
+            cpu: 1024
+            memory: 1024
+            command: "exec puma -p 3001 -C config/puma.rb"
   # ...
 ```
 
 
 ## Requirements
 
-There are three requirements when defining an `nginx` sidecar in Hopper:
+There is only one required field when defining an `nginx` sidecar in Hopper:
 
 - `nginx_port` must be set to the port nginx should bind to.
-- `app_port` must be set to the port that the application is bound to inside the `app` container.
-- `container_name` must be set to the name of your service, e.g. if your service is called `web` then this field is `web`.
+
+### App port
+
+`app_port` can be set to define what port your application container is listening on and this is the port `nginx` will forward requests to.
+
+By default if you don't define an `app_port` then it will be set to the value of `nginx_port`.
+
+### Nginx Container Name
+
+`container_name` can be set to change the name of the `nginx` container.
+
+By default the container name will be set to the name of the service which is usually what you want.
 
 ## Optional Customisations
 
 `nginx` can be customised using environment variables, these are passed to the `environment` field of the `nginx` config:
-
 ```yaml
 services:
-  web:
+  - type: Hopper::Services::ECS::Service
+    name: web
     sidecars:
       nginx:
-        container_name: web
         nginx_port: 8008
-        app_port: 8008
         environment:
           - name: APP_HOST
             value: 'app-worker'
           # ...
+    taskDefinition:
+      # ...
 ```
 
 Here is a list of available customisation environment variables:


### PR DESCRIPTION
Really simple README change, basically Hopper will now use sensible defaults for `container_name` and `app_port`

Ticket number NEC-2356
https://deliveroo.atlassian.net/browse/NEC-2356
